### PR TITLE
Fix for ENOENT: no such file or directory

### DIFF
--- a/script/build_src.js
+++ b/script/build_src.js
@@ -41,9 +41,9 @@ fs.copyFile('./node_modules/jquery/dist/jquery.min.js', 'src/ptk/packages/jquery
 fs.copyFile('./node_modules/jquery/dist/jquery.min.map', 'src/ptk/packages/jquery/jquery.min.map', (err) => {
     if (err) throw err;
 });
-fs.copyFile('./node_modules/datatables.net/js/jquery.dataTables.min.js', 'src/ptk/packages/jquery/jquery.dataTables.min.js', (err) => {
-    if (err) throw err;
-});
+// fs.copyFile('./node_modules/datatables.net/js/jquery.dataTables.min.js', 'src/ptk/packages/jquery/jquery.dataTables.min.js', (err) => {
+//     if (err) throw err;
+// });
 
 
 //semantic-ui / fomantic-ui


### PR DESCRIPTION
### **Fix Build Error by Commenting Out Redundant File Copy**

**Issue:**
When using the `README.md` from a freshly cloned repository, running the command `npm run build` results in the following error:

```
file:///Users/erdem/Desktop/workbench/pentestkit/script/build_src.js:45
    if (err) throw err;
             ^

[Error: ENOENT: no such file or directory, copyfile './node_modules/datatables.net/js/jquery.dataTables.min.js' -> 'src/ptk/packages/jquery/jquery.dataTables.min.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'copyfile',
  path: './node_modules/datatables.net/js/jquery.dataTables.min.js',
  dest: 'src/ptk/packages/jquery/jquery.dataTables.min.js'
}
```

**Cause:**
The build script attempts to copy `jquery.dataTables.min.js` from `./node_modules/datatables.net/js/` to `src/ptk/packages/jquery/`. However, the destination file already exists, leading to the `ENOENT` (Error NO ENTry) since the source path might be incorrect or unnecessary.

**Solution:**
Commented out the file copy section in `build_src.js` to prevent the error. This section is retained (commented out) as it may be useful for future testing and tweaking.

**Changes Made:**
- **File Modified:** `script/build_src.js`
- **Modification:** Commented out the following lines to skip copying `jquery.dataTables.min.js`:

  ```javascript
  // fs.copyFile(
  //   './node_modules/datatables.net/js/jquery.dataTables.min.js',
  //   'src/ptk/packages/jquery/jquery.dataTables.min.js',
  //   (err) => {
  //     if (err) throw err;
  //   }
  // );
  ```

**Impact:**
- **Build Process:** The `npm run build` command should now execute without encountering the `ENOENT` error.
- **Codebase:** The commented-out code remains in place for potential future use during testing or adjustments, ensuring flexibility.

