### PR TITLE
Add ID to the extension to make it to be packaged on different Linux distributions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -86,5 +86,11 @@
                 "<all_urls>"
             ]
         }
-    ]
+    ],
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "pentestkit@DenisPodgurskii",
+        "strict_min_version": "102.0"
+      }
+    }
 }

--- a/src/manifest2.json
+++ b/src/manifest2.json
@@ -3,7 +3,7 @@
     "name": "OWASP Penetration Testing Kit",
     "short_name": "OWASP PTK",
     "description": "OWASP Penetration Testing Kit",
-    "version": "8.9.2",
+    "version": "8.9.3",
     "manifest_version": 2,
     "background": {
         "page": "ptk/background.html"
@@ -61,5 +61,11 @@
         "ptk/*.map",
         "ptk/*.png",
         "ptk/*.json"
-    ]
+    ],
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "pentestkit@DenisPodgurskii",
+        "strict_min_version": "60.0"
+      }
+    }
 }


### PR DESCRIPTION
A missing ID prevents the installation of the extension by packaging. By this PR, will be possible to package the extension in order to make it installable at system-level.

@DenisPodgurskii can you please give a look to this? Can you also publish a minor release so I can package it to Fedora?

I applied `8.9.3` on the manifest.json file.

If you can make it available also on Firefox Addon webpage, it would be great.